### PR TITLE
fix serious typo!

### DIFF
--- a/bin/secondary/pipeline
+++ b/bin/secondary/pipeline
@@ -421,7 +421,7 @@ sub procFQ {
 		    'file'	=> $file,
 		    'filetype'	=> 'FASTQ',
 		    'sample'	=> $prefix_list[$i],
-		    'rgid'	=> $readgroup[$i],
+		    'rg'	=> $readgroup[$i],
 		    'lb'	=> $library[$i],
 		    'pl'    	=> $platform[$i],
 		    'rank'	=> $k,


### PR DESCRIPTION
fix a typo in object field variable assignment, so that a unique read group will be created for each sample in multi-sample analysis scenario.

@kaichop , I added you as a reviewer. Let me know if you don't want to do this in the future. Thanks!